### PR TITLE
removed 2nd argument of parseFloat

### DIFF
--- a/paint.js
+++ b/paint.js
@@ -38,8 +38,8 @@ class SmoothCornersPainter {
     const smooth = this.superellipse(
       width,
       height,
-      parseFloat(nX, 10),
-      parseFloat(nY, 10)
+      parseFloat(nX),
+      parseFloat(nY)
     );
 
     ctx.fillStyle = "#000";


### PR DESCRIPTION
Radix as the second argument [works only](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat) for `parseInt`. So it should be removed.